### PR TITLE
Update metadata methods

### DIFF
--- a/dbtc/utils.py
+++ b/dbtc/utils.py
@@ -1,6 +1,9 @@
 # stdlib
 import json
+import re
 from typing import Any
+
+__all__ = ['listify', 'json_listify', 'camel_to_snake']
 
 
 def listify(value: Any):
@@ -15,3 +18,7 @@ def json_listify(value: Any):
         return json.dumps(listify(value))
 
     return value
+
+
+def camel_to_snake(str):
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', str).lower()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,61 @@
+JOB_ID = 73796
+IDENTIFIERS = {
+    'exposure': 'sales_by_region',
+    'macro': 'macro.tpch.money',
+    'model': 'model.tpch.dim_customers',
+    'seed': 'seed.tpch.country_codes',
+    'test': 'test.tpch.unique_fct_order_items_order_item_key',
+    'source': 'source.tpch.tpch.customer',
+    'snapshot': 'snapshot.tpch.tpch_customer_snapshot',
+}
+
+COMMON_FIELDS = [
+    'run_id',
+    'account_id',
+    'project_id',
+    'environment_id',
+    'job_id',
+    'unique_id',
+    'name',
+]
+SPECIFIC_FIELDS = {
+    'exposure': ['parentsSources.name'],
+    'metric': ['parents_models.columns.name'],
+    'model': ['parents_sources.criteria.error_after.period'],
+    'source': ['criteria.warnAfter.count'],
+    'snapshot': ['parentsModels.unique_id'],
+}
+
+
+def test_methods_with_fields(dbtc_client):
+    for resource, identifier in IDENTIFIERS.items():
+        fields = COMMON_FIELDS + SPECIFIC_FIELDS.get(resource, [])
+        method = f'get_{resource}'
+        data = getattr(dbtc_client.metadata, method)(JOB_ID, identifier, fields=fields)
+        assert 'data' in data
+        method += 's'
+        data = getattr(dbtc_client.metadata, method)(JOB_ID, fields=fields)
+        assert 'data' in data
+
+
+def test_methods_no_fields(dbtc_client):
+    for resource, identifier in IDENTIFIERS.items():
+        method = f'get_{resource}'
+        data = getattr(dbtc_client.metadata, method)(JOB_ID, identifier)
+        assert 'data' in data
+        method += 's'
+        data = getattr(dbtc_client.metadata, method)(JOB_ID)
+        assert 'data' in data
+
+
+def test_query_no_variables(dbtc_client):
+    query = f'{{models(jobId: {JOB_ID}) {{uniqueId}}}}'
+    data = dbtc_client.metadata.query(query)
+    assert 'data' in data
+
+
+def test_query_with_variables(dbtc_client):
+    query = 'query GetMetadata($jobId: Int!) {models(jobId: $jobId) {uniqueId}}'
+    variables = {'jobId': JOB_ID}
+    data = dbtc_client.metadata.query(query, variables)
+    assert 'data' in data


### PR DESCRIPTION
- Add a `query` method that allows a user to write graphql
- Add `fields` argument to each method that allows a user to limit what's returned from the API in a similar way that writing the GraphQL query would.

https://loom.com/share/5be093114c1d4e02a1bcc27c5976a4b2