### PR TITLE
Fix Autoscaling CI - Remove additional read-only field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.6] - 2023-02-28
+
+### Fixed
+- An additional read-only field from a job definition needed to be removed prior to creating the cloned job.  500 errors were occuring because of this.
+
 ## [0.3.5] - 2023-02-22
 
 ### Added

--- a/dbtc/_version.py
+++ b/dbtc/_version.py
@@ -1,4 +1,1 @@
-# third party
-from importlib_metadata import version
-
-__version__ = version('dbtc')
+__version__ = '0.3.6'

--- a/dbtc/client/admin.py
+++ b/dbtc/client/admin.py
@@ -1331,7 +1331,9 @@ class _AdminClient(_Client):
                     current_job = self.get_job(account_id, job_id).get('data', {})
 
                     # Alter the current job definition so it can be cloned
-                    current_job.pop('is_deferrable')
+                    read_only_fields = ['is_deferrable', 'raw_dbt_version']
+                    for read_only_field in read_only_fields:
+                        current_job.pop(read_only_field)
                     current_job['id'] = None
                     now = datetime.now().strftime("%m/%d/%Y %H:%M:%S")
                     current_job['name'] = current_job['name'] + f' [CLONED {now}]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbtc"
-version = "0.3.5"
+version = "0.3.6"
 description = "An unaffiliated python wrapper for dbt Cloud APIs"
 authors = ["Doug Guthrie <douglas.p.guthrie@gmail.com>"]
 documentation = "https://dbtc.dpguthrie.com"


### PR DESCRIPTION
An additional read-only field was added to the response for `get_job` which needed to be removed if using the definition as part of a clone (this was causing the autoscaling CI functionality to error out)