### PR TITLE
Fix arguments for python methods -- cloud client

### DIFF
--- a/dbtc/client/admin.py
+++ b/dbtc/client/admin.py
@@ -172,17 +172,20 @@ class _AdminClient(_Client):
 
     @v3
     def assign_user_to_group(
-        self, account_id: int, project_id: int, payload: Dict
+        self, account_id: int, payload: Dict
     ) -> Dict:
         """Assign a user to a group
 
         Args:
             account_id (int): Numeric ID of the account
-            project_id (int): Numeric ID of the project
             payload (dict): Dictionary representing the user to assign
+            { 
+                "user_id": int,
+                "desired_group_ids": list(int)
+            }
         """
         return self._simple_request(
-            f'accounts/{account_id}/projects/{project_id}/assign-groups/',
+            f'accounts/{account_id}/assign-groups/',
             method='post',
             json=payload,
         )

--- a/dbtc/client/admin.py
+++ b/dbtc/client/admin.py
@@ -512,16 +512,25 @@ class _AdminClient(_Client):
         )
 
     @v3
-    def delete_user_group(self, account_id: int, group_id: int) -> Dict:
+    def delete_user_group(self, account_id: int, group_id: int, payload: Dict) -> Dict:
         """Delete group for a specified account
 
         Args:
             account_id (int): Numeric ID of the account
             group_id (int): Numeric ID of the group to delete
+            payload (dict): Dictionary representing the group to delete with the format
+                {
+                    "account_id": int,
+                    "name": str,
+                    "id": int,
+                    "state":2, 
+                    "assign_by_default":false,
+                    "sso_mapping_groups": list
+                }
         """
         return self._simple_request(
             f'accounts/{account_id}/groups/{group_id}/',
-            method='post',
+            method='post', payload = payload
         )
 
     @v2

--- a/docs/guide/cloud.md
+++ b/docs/guide/cloud.md
@@ -545,7 +545,7 @@ The `cloud` property on the `dbtCloudClient` class contains methods that allow a
 
     Assuming that `client` is an instance of `dbtCloudClient`
     ```py
-    client.cloud.assign_user_to_group(account_id, project_id, payload)
+    client.cloud.assign_user_to_group(account_id, payload)
     ```
 
 === "CLI"
@@ -602,7 +602,7 @@ The `cloud` property on the `dbtCloudClient` class contains methods that allow a
 
     Assuming that `client` is an instance of `dbtCloudClient`
     ```py
-    client.cloud.delete_group(account_id, group_id)
+    client.cloud.delete_group(account_id, group_id, payload)
     ```
 
 === "CLI"
@@ -610,6 +610,19 @@ The `cloud` property on the `dbtCloudClient` class contains methods that allow a
     Assuming that `DBT_CLOUD_ACCOUNT_ID` environment variable has been set.
     ```bash
     dbtc delete-environment --group-id=1
+    ```
+
+=== "Payload"
+
+    ```py
+    payload = {
+        'account_id': 1,
+        'name': '{{ group_name }}',
+        'id': 1,
+        'state':2, 
+        'assign_by_default': False,
+        'sso_mapping_groups': []
+    }
     ```
 
 ### list_groups

--- a/docs/guide/cloud.md
+++ b/docs/guide/cloud.md
@@ -1013,7 +1013,7 @@ The `cloud` property on the `dbtCloudClient` class contains methods that allow a
 
     Assuming that `client` is an instance of `dbtCloudClient`
     ```py
-    client.cloud.get_project("name")
+    client.cloud.get_project_by_name(account_id, project_name)
     ```
 
 === "CLI"


### PR DESCRIPTION
# Type of change  
- Fix  
- Docs  

# Related
This closes #86 

# Description  
There are some methods with invalid arguments in the admin client:

- `delete_user_group` --> needs a `payload` similar to `create_user_group`
- `assign_user_to_group` --> does not require `project_id`

This PR updates the methods definition using the ["unofficial" docs](https://documenter.getpostman.com/view/14183654/UVsSNiXC).

It also updates the Python-relevant docs for those methods changed, as well as for the `get_project_by_name`.
